### PR TITLE
Permute image dimensions before normalizing

### DIFF
--- a/python/test.py
+++ b/python/test.py
@@ -144,7 +144,7 @@ for (ref_image_idx, ref_image) in enumerate(sparse_model.image_list.images):
 	image_height = ref_camera.height
 	shared_data["ready_e"].wait()
 	ref_img_full = shared_data["ref_img_full"]
-	VGG_tensor = Variable(VGG_normalize(torch.FloatTensor(ref_img_full)).permute(2, 0, 1).unsqueeze(0), volatile = True)
+	VGG_tensor = Variable(VGG_normalize(torch.FloatTensor(ref_img_full).permute(2, 0, 1)).unsqueeze(0), volatile = True)
 	if use_gpu:
 		VGG_tensor = VGG_tensor.cuda()
 	VGG_scaling_factor = 0.01


### PR DESCRIPTION
to avoid error

```Creating VGG model...
Successfully created VGG model.
Start working on image 0/43.
Traceback (most recent call last):
  File "python/test.py", line 147, in <module>
    VGG_tensor = Variable(VGG_normalize(torch.FloatTensor(ref_img_full)).permute(2, 0, 1).unsqueeze(0), volatile = True)
  File "/home/rasmus/anaconda2/envs/pytorch_p27/lib/python2.7/site-packages/torchvision/transforms/transforms.py", line 164, in __call__
    return F.normalize(tensor, self.mean, self.std, self.inplace)
  File "/home/rasmus/anaconda2/envs/pytorch_p27/lib/python2.7/site-packages/torchvision/transforms/functional.py", line 208, in normalize
    tensor.sub_(mean[:, None, None]).div_(std[:, None, None])
RuntimeError: The size of tensor a (3949) must match the size of tensor b (3) at non-singleton dimension 0
```

with PyTorch 0.4.0 and newer. With this fix, I can get good looking disparity images, but please comment if the fix is actually correct. Or do I need to swap the dimensions of `mean` and `std` values when creating `VGG_normalize`?

